### PR TITLE
Cuadros de preguntas en componentes

### DIFF
--- a/imports/ui/visualization/scrollytelling.jsx
+++ b/imports/ui/visualization/scrollytelling.jsx
@@ -1555,6 +1555,7 @@ class Scrollytelling extends React.Component {
             if (Meteor.user().profile.q1.split("/")[0] === "no") {
                 return (
                     <div>
+                        {/*Cada una de las preguntas se deberia encapsular en un componente igual*/}
                         <div className="panel panel-white post panel-shadow questions">
                             <fieldset className="form-group" onChange={this.handleChangePregunta1}>
                                 <legend>¿Estás de acuerdo con la realización del acuerdo de paz con las FARC?</legend>
@@ -1577,6 +1578,7 @@ class Scrollytelling extends React.Component {
             else if (Meteor.user().profile.q1.split("/")[0] === "yes") {
                 return (
                     <div>
+                        {/*Cada una de las preguntas se deberia encapsular en un componente igual*/}
                         <div className="panel panel-white post panel-shadow questions">
                             <fieldset className="form-group" onChange={this.handleChangePregunta1}>
                                 <legend>¿Estás de acuerdo con la realización del acuerdo de paz con las FARC?</legend>
@@ -1590,7 +1592,8 @@ class Scrollytelling extends React.Component {
 
         else {
             return (
-                <div>
+                <div
+                    {/*Cada una de las preguntas se deberia encapsular en un componente igual*/}
                     <div className="panel panel-white post panel-shadow questions">
                         <fieldset className="form-group" onChange={this.handleChangePregunta1}>
                             <legend>¿Estás de acuerdo con la realización del acuerdo de paz con las FARC?</legend>


### PR DESCRIPTION
## Encapsular secciones de la aplicación en componentes de react
A pesar de que es una SPA, se podrían encapsular muchas de sus funciones en componentes o simplemente archivos con sus funcionalidades. 

Por ejemplo, sería útil encapsular cada uno de los cuadros de preguntas (¿Estás de acuerdo con ...) en un componente  **Pregunta**  al cual se le ingresara como props el texto.

Esto no solo reduciría las 2021 líneas de código del archivo, sino que haría más sencillo entender y modificar su código.